### PR TITLE
Bump libc dependency to 0.2.70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ sys-info = "=0.5.8"
 thiserror = "1.0.15"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.66"
+libc = "0.2.70"
 
 
 [target."cfg(windows)".dependencies]


### PR DESCRIPTION
libc 0.2.70 includes https://github.com/rust-lang/libc/pull/1745 which
fixes compilation for riscv64gc-unknown-linux-gnu.