### PR TITLE
Build BSD on PRs

### DIFF
--- a/.github/workflows/linux-builds-on-pr.yaml
+++ b/.github/workflows/linux-builds-on-pr.yaml
@@ -19,6 +19,8 @@ jobs:
           - x86_64-unknown-linux-gnu
           - armv7-unknown-linux-gnueabihf
           - aarch64-linux-android
+          - x86_64-unknown-freebsd        # skip-master
+          - x86_64-unknown-netbsd         # skip-master
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES

--- a/.github/workflows/linux-builds-on-stable.yaml
+++ b/.github/workflows/linux-builds-on-stable.yaml
@@ -25,8 +25,8 @@ jobs:
           - i686-unknown-linux-gnu        # skip-pr skip-master
           - arm-unknown-linux-gnueabi     # skip-pr skip-master
           - arm-unknown-linux-gnueabihf   # skip-pr skip-master
-          - x86_64-unknown-freebsd        # skip-pr skip-master
-          - x86_64-unknown-netbsd         # skip-pr skip-master
+          - x86_64-unknown-freebsd        # skip-master
+          - x86_64-unknown-netbsd         # skip-master
           - powerpc-unknown-linux-gnu     # skip-pr skip-master
           - powerpc64le-unknown-linux-gnu # skip-pr skip-master
           - mips-unknown-linux-gnu        # skip-pr skip-master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,11 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sys-info = "0.6.1"
+cfg-if="0.1.10"
 thiserror = "1.0.20"
+
+[target.'cfg(any(windows, target_os="macos", target_os="linux"))'.dependencies]
+sys-info = "0.6.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.78"

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -33,8 +33,8 @@ jobs:
           - i686-unknown-linux-gnu        # skip-pr skip-master
           - arm-unknown-linux-gnueabi     # skip-pr skip-master
           - arm-unknown-linux-gnueabihf   # skip-pr skip-master
-          - x86_64-unknown-freebsd        # skip-pr skip-master
-          - x86_64-unknown-netbsd         # skip-pr skip-master
+          - x86_64-unknown-freebsd        # skip-master
+          - x86_64-unknown-netbsd         # skip-master
           - powerpc-unknown-linux-gnu     # skip-pr skip-master
           - powerpc64le-unknown-linux-gnu # skip-pr skip-master
           - mips-unknown-linux-gnu        # skip-pr skip-master

--- a/ci/docker/x86_64-unknown-freebsd/Dockerfile
+++ b/ci/docker/x86_64-unknown-freebsd/Dockerfile
@@ -1,4 +1,4 @@
 FROM rust-x86_64-unknown-freebsd
 
-ENV CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd10-clang \
-    CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER=x86_64-unknown-freebsd10-clang
+ENV CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd11-clang \
+    CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER=x86_64-unknown-freebsd11-clang


### PR DESCRIPTION
While rustup doesn't build for BSD in CI, it does ship it, so lets make
sure BSD works always for effective-limits.