### PR TITLE
enable sysinfo support on illumos systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "Apache-2.0"
 cfg-if="0.1.10"
 thiserror = "1.0.20"
 
-[target.'cfg(any(windows, target_os="macos", target_os="linux", target_os="freebsd"))'.dependencies]
+[target.'cfg(any(windows, target_os="macos", target_os="linux", target_os="freebsd", target_os="illumos", target_os="solaris"))'.dependencies]
 sys-info = "0.7.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ cfg_if! {
                  target_os="macos",
                  target_os="linux",
                  target_os="freebsd",
+                 target_os="illumos",
+                 target_os="solaris",
                 ))] {
         #[derive(thiserror::Error, Debug)]
         pub enum Error {
@@ -160,6 +162,8 @@ pub fn memory_limit() -> Result<u64> {
                      target_os="macos",
                      target_os="linux",
                      target_os="freebsd",
+                     target_os="illumos",
+                     target_os="solaris",
                     ))] {
             let info = sys_info::mem_info()?;
             let total_ram = info.total * 1024;
@@ -195,6 +199,8 @@ mod tests {
         target_os = "macos",
         target_os = "linux",
         target_os = "freebsd",
+        target_os = "illumos",
+        target_os = "solaris",
     ))]
     #[test]
     fn it_works() -> Result<()> {
@@ -402,6 +408,8 @@ mod tests {
         target_os = "macos",
         target_os = "linux",
         target_os = "freebsd",
+        target_os = "illumos",
+        target_os = "solaris",
     ))]
     #[test]
     fn test_no_ulimit() -> Result<()> {


### PR DESCRIPTION
Support for illumos systems was added to the sys-info crate some time
ago, and was working with effective-limits, but as of 887a5a06f62
appears to have effectively been turned off at build time.

With this change, I can `cargo build` and `cargo test` without failures:

```
 $ cargo test
   Compiling effective-limits v0.5.3-alpha.0 (/ws/safari/effective-limits.rs)
    Finished test [unoptimized + debuginfo] target(s) in 0.41s
     Running target/debug/deps/effective_limits-91122e1efdd826d7

running 2 tests
test tests::test_min_opt ... ok
test tests::test_ulimit ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/test_limited-060e6d3400d5471b

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests effective-limits

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

I expect this will make the `error: 'sysinfo not supported on this platform'` message emitted from `rustup` on illumos systems go away.