### PR TITLE
Support freebsd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ license = "Apache-2.0"
 cfg-if="0.1.10"
 thiserror = "1.0.20"
 
-[target.'cfg(any(windows, target_os="macos", target_os="linux"))'.dependencies]
-sys-info = "0.6.1"
+[target.'cfg(any(windows, target_os="macos", target_os="linux", target_os="freebsd"))'.dependencies]
+sys-info = "0.7.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.78"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,11 @@ use std::cmp::min;
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(any(windows, target_os="macos", target_os="linux"))] {
+    if #[cfg(any(windows,
+                 target_os="macos",
+                 target_os="linux",
+                 target_os="freebsd",
+                ))] {
         #[derive(thiserror::Error, Debug)]
         pub enum Error {
             #[error("sysinfo failure")]
@@ -152,7 +156,11 @@ fn ulimited_memory() -> Result<Option<u64>> {
 /// a-priori selection of memory limits.
 pub fn memory_limit() -> Result<u64> {
     cfg_if! {
-        if #[cfg(any(windows, target_os="macos", target_os="linux"))] {
+        if #[cfg(any(windows,
+                     target_os="macos",
+                     target_os="linux",
+                     target_os="freebsd",
+                    ))] {
             let info = sys_info::mem_info()?;
             let total_ram = info.total * 1024;
             let ulimit_mem = ulimited_memory()?;
@@ -182,7 +190,12 @@ mod tests {
 
     use super::*;
 
-    #[cfg(any(windows, target_os = "macos", target_os = "linux"))]
+    #[cfg(any(
+        windows,
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "freebsd",
+    ))]
     #[test]
     fn it_works() -> Result<()> {
         assert_ne!(0, memory_limit()?);
@@ -384,7 +397,12 @@ mod tests {
         Ok(limit)
     }
 
-    #[cfg(any(windows, target_os = "macos", target_os = "linux"))]
+    #[cfg(any(
+        windows,
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "freebsd",
+    ))]
     #[test]
     fn test_no_ulimit() -> Result<()> {
         // This test depends on the dev environment being run uncontained.


### PR DESCRIPTION
Building atop #12 this adds FreeBSD to the sys-info supported set in effective-limits.

I can't test this locally, so pushing this in the hope that github will tell me if it'll work.