### PR TITLE
Update sys-info to v0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if="0.1.10"
 thiserror = "1.0.20"
 
 [target.'cfg(any(windows, target_os="macos", target_os="linux", target_os="freebsd", target_os="illumos", target_os="solaris"))'.dependencies]
-sys-info = "0.7.0"
+sys-info = "0.8.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.78"


### PR DESCRIPTION
This PR updates sys-info dependency to v0.8 which improves Windows support to be arch-independent and enables building rustup for Windows on ARM64: https://github.com/rust-lang/rustup/issues/2612