### PR TITLE
Update sys-info to v0.9

### DIFF
--- a/.github/workflows/windows-builds-on-master.yaml
+++ b/.github/workflows/windows-builds-on-master.yaml
@@ -24,11 +24,11 @@ jobs:
           - x86_64-pc-windows-gnu # skip-pr
         include:
           - target: x86_64-pc-windows-gnu
-            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-4.9.2-release-win32-seh-rt_v4-rev4.7z
+            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
             mingwdir: mingw64
           - target: i686-pc-windows-gnu
             mingwdir: mingw32
-            mingw: https://ci-mirrors.rust-lang.org/rustc/i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z
+            mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
     steps:
       - uses: actions/checkout@v2
         # v2 defaults to a shallow checkout, but we need at least to the previous tag

--- a/.github/workflows/windows-builds-on-pr.yaml
+++ b/.github/workflows/windows-builds-on-pr.yaml
@@ -21,11 +21,11 @@ jobs:
           - x86_64-pc-windows-msvc
         include:
           - target: x86_64-pc-windows-gnu
-            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-4.9.2-release-win32-seh-rt_v4-rev4.7z
+            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
             mingwdir: mingw64
           - target: i686-pc-windows-gnu
             mingwdir: mingw32
-            mingw: https://ci-mirrors.rust-lang.org/rustc/i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z
+            mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
     steps:
       - uses: actions/checkout@v2
         # v2 defaults to a shallow checkout, but we need at least to the previous tag

--- a/.github/workflows/windows-builds-on-stable.yaml
+++ b/.github/workflows/windows-builds-on-stable.yaml
@@ -24,11 +24,11 @@ jobs:
           - i686-pc-windows-gnu # skip-pr skip-master
         include:
           - target: x86_64-pc-windows-gnu
-            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-4.9.2-release-win32-seh-rt_v4-rev4.7z
+            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
             mingwdir: mingw64
           - target: i686-pc-windows-gnu
             mingwdir: mingw32
-            mingw: https://ci-mirrors.rust-lang.org/rustc/i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z
+            mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
     steps:
       - uses: actions/checkout@v2
         # v2 defaults to a shallow checkout, but we need at least to the previous tag

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if="0.1.10"
 thiserror = "1.0.20"
 
 [target.'cfg(any(windows, target_os="macos", target_os="linux", target_os="freebsd", target_os="illumos", target_os="solaris"))'.dependencies]
-sys-info = "0.7.0"
+sys-info = "0.9.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.78"

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -32,11 +32,11 @@ jobs:
           - i686-pc-windows-gnu # skip-pr skip-master
         include:
           - target: x86_64-pc-windows-gnu
-            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-4.9.2-release-win32-seh-rt_v4-rev4.7z
+            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
             mingwdir: mingw64
           - target: i686-pc-windows-gnu
             mingwdir: mingw32
-            mingw: https://ci-mirrors.rust-lang.org/rustc/i686-4.9.2-release-win32-dwarf-rt_v4-rev4.7z
+            mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
     steps:
       - uses: actions/checkout@v2
         # v2 defaults to a shallow checkout, but we need at least to the previous tag


### PR DESCRIPTION
This PR updates sys-info dependency to v0.9 which improves Windows support to be arch-independent and enables building rustup for Windows on ARM64: https://github.com/rust-lang/rustup/issues/2612

This is a re-post of this PR: #14 

Should also help with #15 