### PR TITLE
Fix compilation on OpenBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "Apache-2.0"
 cfg-if="0.1.10"
 thiserror = "1.0.20"
 
-[target.'cfg(any(windows, target_os="macos", target_os="linux", target_os="freebsd", target_os="illumos", target_os="solaris"))'.dependencies]
+[target.'cfg(any(windows, target_os="macos", target_os="linux", target_os="freebsd", target_os="openbsd", target_os="illumos", target_os="solaris"))'.dependencies]
 sys-info = "0.9.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ cfg_if! {
                  target_os="macos",
                  target_os="linux",
                  target_os="freebsd",
+                 target_os="openbsd",
                  target_os="illumos",
                  target_os="solaris",
                 ))] {
@@ -55,7 +56,7 @@ fn min_opt(left: u64, right: Option<u64>) -> u64 {
 }
 
 #[allow(dead_code)]
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os="openbsd")))]
 fn ulimited_memory() -> Result<Option<u64>> {
     let mut out = libc::rlimit {
         rlim_cur: 0,
@@ -94,6 +95,11 @@ fn ulimited_memory() -> Result<Option<u64>> {
     Ok(address_limit
         .or(data_limit)
         .map(|left| min_opt(left, data_limit)))
+}
+
+#[cfg(target_os="openbsd")]
+fn ulimited_memory() -> Result<Option<u64>> {
+    Ok(None)
 }
 
 #[cfg(not(unix))]
@@ -162,6 +168,7 @@ pub fn memory_limit() -> Result<u64> {
                      target_os="macos",
                      target_os="linux",
                      target_os="freebsd",
+                     target_os="openbsd",
                      target_os="illumos",
                      target_os="solaris",
                     ))] {


### PR DESCRIPTION
This PR fixes compilation on OpenBSD by providing a stub for `ulimited_memory()`.
The original implementation for unix doesn't work for OpenBSD, because it doesn't have `RLIMIT_AS`.
OpenBSD does provide `RLIMIT_DATA` though.

Signed-off-by: Benjamin Stürz <benni@stuerz.xyz>