### PR TITLE
fix test compilation issues on various architectures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "effective-limits"
 readme = "README.md"
 repository = "https://github.com/rbtcollins/effective-limits.rs"
 version = "0.5.5"
-
+exclude = ["/ci/"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,7 +377,7 @@ mod tests {
                     unsafe {
                         cmd.pre_exec(move || {
                             let lim = libc::rlimit {
-                                rlim_cur: ulimit,
+                                rlim_cur: ulimit as _,
                                 rlim_max: libc::RLIM_INFINITY,
                             };
                             match libc::setrlimit(rlimit_as, &lim as *const libc::rlimit) {


### PR DESCRIPTION
This simple change should fix #42 - or at least it does fix the issue for me on i686, and since the failure is the same on the other 32-bit architectures, I assume this PR should also fix those. The `foo as _` trick is something I've seen used in other crates that deal with `libc` bindings that have different type signatures on different architectures.

I've also added a setting that excludes the "ci" directory from published crates - the files in it are larger than the rest of the crate combined (including the license text!) and they are not needed when using the crate as distributed via crates.io.