### PR TITLE
Add support for OpenBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.5.5"
 cfg-if = "0.1.10"
 thiserror = "1.0.37"
 
-[target.'cfg(any(windows, target_os="macos", target_os="linux", target_os="freebsd", target_os="illumos", target_os="solaris", target_os="netbsd"))'.dependencies]
+[target.'cfg(any(windows, target_os="macos", target_os="linux", target_os="freebsd", target_os="illumos", target_os="solaris", target_os="netbsd", target_os="openbsd"))'.dependencies]
 sys-info = "0.9.1"
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
This PR adds support for OpenBSD. OpenBSD does not have the `RLIMIT_AS` constant ([https://github.com/openbsd/src/blob/master/sys/sys/resource.h](https://github.com/openbsd/src/blob/master/sys/sys/resource.h)) so like #19 I have added a stub function for `ulimited_memory` on OpenBSD that returns `Ok(None)`. `sys_info` supports OpenBSD, so `memory_limit` is still functional. I have tested `memory_limit` as demonstrated in `examples/memory.rs`, which worked.

I have also disabled the `test_ulimit` test for OpenBSD, as the `RLIMIT_AS` functionality is not present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rbtcollins/effective-limits.rs/63)
<!-- Reviewable:end -->
